### PR TITLE
Improvements to the build process

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Linting and Testing
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -26,7 +26,6 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools>=46.4.0
     - name: Build package
       run: |
         python -m pip install -e .[testing,linting,formatting]
@@ -41,7 +40,7 @@ jobs:
       if: startsWith(matrix.platform,'ubuntu') && matrix.python-version == '3.8'
     - name: Lint source with pylint
       run: |
-        pylint src/cholupdates
+        pylint src/cholupdates --ignore-paths=src/cholupdates/_version.py
       if: always()
     - name: Lint tests with pylint
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,11 +20,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
+        pip install --upgrade build twine
+    - name: Build package using `build`
+      env:
+        CHOLUPDATES_DISABLE_CYTHON_BUILD: 1
+      run: |
+        python -m build
+    - name: Publish to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,14 @@
 requires = [
     "setuptools>=46.4.0",
     "wheel",
+    "setuptools_scm[toml]>=6.0",
     "Cython",
     "scipy",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/cholupdates/_version.py"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ name = cholupdates
 description = Efficient Updates to Cholesky Factors after Matrix Modifications
 url = https://cholupdates.readthedocs.io/
 author = Marvin Pförtner
-author-email = marvin.pfoertner@icloud.com
+author_email = marvin.pfoertner@icloud.com
 license = MIT
-long-description = file: README.md
-long-description-content-type = text/markdown
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = low-rank, rank-1, rank, one, update, downdate, cholesky
 platforms = any
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ include_package_data = True
 package_dir =
     =src
 zip_safe = False  # Needed for Cython to work
+setup_requires =
+    setuptools_scm[toml]>=6.0  # This is only here for compatibility reasons
 install_requires =
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = cholupdates
-version = attr: cholupdates.__version__
 description = Efficient Updates to Cholesky Factors after Matrix Modifications
 url = https://cholupdates.readthedocs.io/
 author = Marvin Pförtner

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
 
+# Cython Extensions
+ext_modules = []
+
 try:
     # isort: off
 
@@ -7,21 +10,25 @@ try:
     from Cython.Build import cythonize
     import scipy  # pylint: disable=unused-import
 
+    import os
+
     # isort: on
 
-    build_cython = True
+    cython_available = True
 except ImportError:
-    build_cython = False
+    cython_available = False
 
-    print("Not building Cython extensions")
-
-# Extensions
-ext_modules = []
+build_cython = cython_available and not (
+    "CHOLUPDATES_DISABLE_CYTHON_BUILD" in os.environ
+    and os.environ["CHOLUPDATES_DISABLE_CYTHON_BUILD"] == "1"
+)
 
 if build_cython:
     ext_modules.extend(
         cythonize("src/cholupdates/rank_1/_seeger_impl_cython.pyx"),
     )
+else:
+    print("Not building Cython extensions")
 
 setup(
     ext_modules=ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 
 try:
+    # isort: off
+
     # This import must come after the setuptools import
-    from Cython.Build import cythonize  # isort: skip
-    import scipy  # isort: skip, pylint: disable=unused-import
+    from Cython.Build import cythonize
+    import scipy  # pylint: disable=unused-import
+
+    # isort: on
 
     build_cython = True
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ else:
 
 setup(
     ext_modules=ext_modules,
+    use_scm_version=True,  # This is only here for compatibility reasons
 )

--- a/src/cholupdates/.gitignore
+++ b/src/cholupdates/.gitignore
@@ -1,3 +1,3 @@
-*.c
+**/*.c
 
 _version.py

--- a/src/cholupdates/.gitignore
+++ b/src/cholupdates/.gitignore
@@ -1,1 +1,3 @@
 *.c
+
+_version.py

--- a/src/cholupdates/__init__.py
+++ b/src/cholupdates/__init__.py
@@ -3,5 +3,6 @@ factorization of low-rank up-/downdates to a matrix with a known Cholesky factor
 """
 
 from . import rank_1
+from ._version import version as _version_str
 
-__version__ = "0.0.1a2"
+__version__ = _version_str

--- a/src/cholupdates/rank_1/_seeger_impl_cython.pyx
+++ b/src/cholupdates/rank_1/_seeger_impl_cython.pyx
@@ -1,3 +1,5 @@
+# cython: language_level = 3
+
 """Cython implementation of the symmetric rank-1 up- and downdate algorithms from
 sections 2 and 3 in [1]_.
 


### PR DESCRIPTION
- read the package version from the most recent git tag
- reactivate triggers for testing and linting CI (these broke because of the master -> main renaming)
- make Cython builds optional, even in PEP517 builds
- fix warnings in setup.cfg
- fix Cython build warning